### PR TITLE
refactor: use shared waitForTimeout helper in query tests

### DIFF
--- a/src/lib/queries/useQuery$.reactivity.test.tsx
+++ b/src/lib/queries/useQuery$.reactivity.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen } from "@testing-library/react"
 import type React from "react"
 import { BehaviorSubject, filter, map, switchMap } from "rxjs"
 import { describe, expect, it } from "vitest"
+import { waitForTimeout } from "../../tests/utils"
 import { QueryClientProvider$ } from "./QueryClientProvider$"
 import { useQuery$ } from "./useQuery$"
 
@@ -60,7 +61,7 @@ describe("useQuery$ live-query reactivity", () => {
     render(<Comp />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -69,7 +70,7 @@ describe("useQuery$ live-query reactivity", () => {
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -100,7 +101,7 @@ describe("useQuery$ live-query reactivity", () => {
     render(<Comp />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -109,7 +110,7 @@ describe("useQuery$ live-query reactivity", () => {
 
     await act(async () => {
       liveQuery$.next(["a", "c"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -145,7 +146,7 @@ describe("useQuery$ live-query reactivity", () => {
     render(<Comp />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -154,7 +155,7 @@ describe("useQuery$ live-query reactivity", () => {
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -185,7 +186,7 @@ describe("useQuery$ live-query reactivity", () => {
     render(<Comp />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(["a"]))
@@ -194,7 +195,7 @@ describe("useQuery$ live-query reactivity", () => {
       liveQuery$.next(["a", "b"])
       liveQuery$.next(["a", "b", "c"])
       liveQuery$.next(["a", "b", "c", "d"])
-      await new Promise((r) => setTimeout(r, 300))
+      await waitForTimeout(300)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -226,7 +227,7 @@ describe("useQuery$ live-query reactivity", () => {
     render(<Comp />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     await act(async () => {
@@ -234,12 +235,12 @@ describe("useQuery$ live-query reactivity", () => {
         queryKey: ["live", "external-refetch"],
         exact: true,
       })
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -271,7 +272,7 @@ describe("useQuery$ live-query reactivity", () => {
     render(<Comp />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     await act(async () => {
@@ -279,12 +280,12 @@ describe("useQuery$ live-query reactivity", () => {
         queryKey: ["live", "invalidate"],
         exact: true,
       })
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(

--- a/src/lib/queries/useQuery$.unmount.test.tsx
+++ b/src/lib/queries/useQuery$.unmount.test.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 import { useState } from "react"
 import { BehaviorSubject, filter, map, switchMap } from "rxjs"
 import { describe, expect, it } from "vitest"
+import { waitForTimeout } from "../../tests/utils"
 import { QueryClientProvider$ } from "./QueryClientProvider$"
 import { useQuery$ } from "./useQuery$"
 
@@ -72,7 +73,7 @@ describe("useQuery$ unmount / remount", () => {
     render(<Host />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -82,7 +83,7 @@ describe("useQuery$ unmount / remount", () => {
     await act(async () => {
       toggle()
       toggle()
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -91,7 +92,7 @@ describe("useQuery$ unmount / remount", () => {
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -133,7 +134,7 @@ describe("useQuery$ unmount / remount", () => {
     render(<Host />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -143,12 +144,12 @@ describe("useQuery$ unmount / remount", () => {
     await act(async () => {
       toggle()
       toggle()
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     await act(async () => {
       liveQuery$.next(["a", "c"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -190,7 +191,7 @@ describe("useQuery$ unmount / remount", () => {
     render(<Host />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(["a"]))
@@ -199,7 +200,7 @@ describe("useQuery$ unmount / remount", () => {
       await act(async () => {
         toggle()
         toggle()
-        await new Promise((r) => setTimeout(r, 50))
+        await waitForTimeout(50)
       })
     }
 
@@ -207,7 +208,7 @@ describe("useQuery$ unmount / remount", () => {
 
     await act(async () => {
       liveQuery$.next(["a", "b"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -258,14 +259,14 @@ describe("useQuery$ unmount / remount", () => {
     render(<Host />, { wrapper: createWrapper(queryClient) })
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(["a"]))
 
     await act(async () => {
       liveQuery$.next(["a", "b"])
-      await new Promise((r) => setTimeout(r, 100))
+      await waitForTimeout(100)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -277,7 +278,7 @@ describe("useQuery$ unmount / remount", () => {
     await act(async () => {
       toggle()
       toggle()
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(
@@ -286,7 +287,7 @@ describe("useQuery$ unmount / remount", () => {
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c", "d"])
-      await new Promise((r) => setTimeout(r, 200))
+      await waitForTimeout(200)
     })
 
     expect(screen.getByTestId("data").textContent).toBe(


### PR DESCRIPTION
## Consolidation: inline `setTimeout` promises → shared `waitForTimeout`

**What was duplicated.** `src/tests/utils.tsx` already exports a `waitForTimeout(ms)` helper (`new Promise((resolve) => setTimeout(resolve, ms))`), and ~10 test files import and use it. Two files never adopted it and instead reimplemented the same wait inline as `await new Promise((r) => setTimeout(r, N))`:

- `src/lib/queries/useQuery$.reactivity.test.tsx` — 14 occurrences
- `src/lib/queries/useQuery$.unmount.test.tsx` — 13 occurrences

**What it became.** All 27 inline promises now call the existing shared helper (`await waitForTimeout(N)`), and each file gains a single `import { waitForTimeout } from "../../tests/utils"`.

**Why it's the same concept.** `waitForTimeout(N)` is *literally* `new Promise((resolve) => setTimeout(resolve, N))` — the replacement is a byte-for-byte behavioral equivalent, just pointed at the canonical helper the rest of the suite already uses. No timing, ordering, or resolution-value change.

**Net LOC delta.** +2 imports / −0 (27 one-for-one line replacements). The win here isn't raw line count but removing 27 ad-hoc reimplementations of a helper that already has one home, so the whole test suite now waits the same way.

### Gates
- `npm run check` (biome) — passes.
- `npx vitest run --typecheck` on both affected files — 10/10 pass, no type errors.
- Baseline recorded before the change (both files green) so no pre-existing failures were masked.

### Further opportunities (left for a future run to keep this PR one story)
Both files also carry local reimplementations of things that already exist / could be shared, deliberately **not** touched here because they change the PR's story and carry slightly more risk:
- A local `isDefined<T>` type guard in each file, while `src/lib/utils/isDefined.ts` already exports one (the two differ in their type-predicate return, which interacts with `--typecheck` and needs care).
- An identical `createQueryClient()` helper duplicated across both files, which would want a new shared home in `src/tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NytK9AeSKMKcmuJvL8QCvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01NytK9AeSKMKcmuJvL8QCvr)_