### PR TITLE
chore: upgrade vitest to 4.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^6.0.2",
         "vite": "^8.1.4",
         "vite-plugin-dts": "^5.0.1",
-        "vitest": "^4.0.17"
+        "vitest": "^4.1.10"
       },
       "peerDependencies": {
         "@tanstack/react-query": "5.x",
@@ -1899,16 +1899,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1917,13 +1917,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.7",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1954,9 +1954,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1967,13 +1967,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1981,14 +1981,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1997,9 +1997,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2007,13 +2007,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -8943,19 +8943,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.7",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/runner": "4.1.7",
-        "@vitest/snapshot": "4.1.7",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -8983,12 +8983,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.7",
-        "@vitest/browser-preview": "4.1.7",
-        "@vitest/browser-webdriverio": "4.1.7",
-        "@vitest/coverage-istanbul": "4.1.7",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^6.0.2",
     "vite": "^8.1.4",
     "vite-plugin-dts": "^5.0.1",
-    "vitest": "^4.0.17"
+    "vitest": "^4.1.10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## The update

| Package | From | To | Type | Scope |
|---|---|---|---|---|
| `vitest` | 4.1.7 | **4.1.10** | patch | devDependency |

Routine patch bump of the test runner. Picked as the most-behind, gate-verified patch: no security fix was resolvable by a single in-range direct-dependency bump this run (see below), so per priority order this is the oldest patch on the core toolchain. Changes across 4.1.8–4.1.10 are bug fixes to the runner/reporters; no config or API changes required. The manifest caret range (`^4.0.17` → `^4.1.10`) was bumped to match the installed floor.

### Gates
Baseline captured on a clean `main` checkout, then re-run with the update applied — no new failures:

| Gate | Baseline | With update |
|---|---|---|
| `npm run check` (biome) | ✅ 89 files | ✅ 89 files |
| `npm run build` (tsc + vite) | ✅ built | ✅ built |
| `npm run test:ci` (vitest run) | ✅ 128 passed | ✅ 128 passed (RUN v4.1.10) |

Only `package.json` + `package-lock.json` changed; no second lockfile introduced.

---

## Pending queue (status report)

### Security advisories — need a maintainer decision
`npm audit` reports 8 vulnerabilities (2 high, 5 moderate, 1 low). **All are transitive, dev-only, and not fixable by a single in-range direct-dependency bump** — the parents (`jsdom`, `semantic-release`) are already at their latest versions, and most live inside the `npm@11.15.0` bundle that `@semantic-release/npm` ships. Resolving them would require `overrides` (which widens transitive constraints) or accepting they don't affect the published `dist`, so they're left for a human:

| Severity | Package | Advisory | Path |
|---|---|---|---|
| HIGH | `undici` (<7.28.0) | GHSA-vmh5-mc38-953g + several more (TLS bypass, header injection, cache poisoning) | `jsdom@29.1.1` (latest, pins undici 7.25.0) & `semantic-release` |
| HIGH | `sigstore` (<=4.1.0) | GHSA-52v5-jr5w-gjxr | bundled in `npm@11.15.0` ← `semantic-release` |
| MOD | `@sigstore/core`, `@sigstore/verify` | GHSA-jfc7-64v2-mr8c, GHSA-xgjw-pm74-86q4 | bundled in `npm@11.15.0` ← `semantic-release` |
| MOD | `tar` (<=7.5.15) | GHSA-vmf3-w455-68vh | bundled in `npm@11.15.0` ← `semantic-release` |
| MOD | `npm` | (via `tar`) | bundled in `semantic-release` |
| MOD | `js-yaml` (4.0.0–4.1.1) | GHSA-h67p-54hq-rp68 | `semantic-release` → `cosmiconfig` |
| LOW | `@babel/core` (<=7.29.0) | GHSA-4x5r-pxfx-6jf8 | build tooling (transitive) |

### Outdated direct dependencies (not yet applied)

**Patches (within range):**
- `@vitejs/plugin-react` 6.0.2 → 6.0.3
- `vite` 8.1.4 → 8.1.5
- `vite-plugin-dts` 5.0.1 → 5.0.3
- `@types/react` 19.2.15 → 19.2.17
- `react` 19.2.6 → 19.2.7 (dev + peer)
- `react-dom` 19.2.6 → 19.2.7 (dev + peer)
- `lint-staged` 17.0.5 → 17.0.8
- `semantic-release` 25.0.3 → 25.0.7
- `@types/node` 25.9.1 → 25.9.5 (within current major 25)

**Minors:**
- `@biomejs/biome` 2.4.15 → 2.5.4
- `@tanstack/react-query` 5.100.14 → 5.101.2 *(peer + dev; should move in lockstep with the persist-client below)*
- `@tanstack/react-query-persist-client` 5.100.14 → 5.101.2 *(same @tanstack family, released together — bundle these two in one PR)*
- `terser` 5.48.0 → 5.49.0

### Deferred majors (not auto-applied — schedule manually)
- **`@types/node` 25.9.1 → 26.1.1** — tracks a newer Node runtime major line; bump only alongside the project's Node target (CI pins Node 25).
- **`typescript` 6.0.3 → 7.0.2** — TypeScript 7.x is a major compiler change; expect new type diagnostics and requires TS-tooling (biome, vite-plugin-dts, react-compiler) compatibility. Needs a dedicated PR.

### Needs manual attention
None from this run — the chosen update passed all gates cleanly. The security advisories above are the only items requiring a human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcMagL4VqF65241Hvv7JKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcMagL4VqF65241Hvv7JKb)_