### PR TITLE
chore: upgrade semantic-release to 25.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "rxjs": "^7.8.0",
-        "semantic-release": "^25.0.3",
+        "semantic-release": "^25.0.8",
         "terser": "^5.46.0",
         "typescript": "^6.0.2",
         "vite": "^8.1.4",
@@ -7650,9 +7650,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rxjs": "^7.8.0",
-    "semantic-release": "^25.0.3",
+    "semantic-release": "^25.0.8",
     "terser": "^5.46.0",
     "typescript": "^6.0.2",
     "vite": "^8.1.4",


### PR DESCRIPTION
## The update

**`semantic-release` `^25.0.3` → `^25.0.8`** — patch (within the existing caret range; constraint respected).

This was selected as the most-behind patch update. It also carries security-hardening fixes that don't appear in the npm advisory DB but are worth landing:

Changelog highlights (25.0.4 → 25.0.8):
- **25.0.7** — fix argument injection via `repositoryUrl` in `package.json`
- **25.0.8** — improved environment-variable masking, prevented template-syntax vulnerabilities, null-value handling in commit messaging
- **25.0.6** — ensure encoded secrets get masked
- **25.0.5 / 25.0.4** — revert of a next-branch change / code-quality fix

Only `semantic-release` itself moved in the lockfile — its transitive deps were already at compatible versions.

### Gates
Baseline on a clean `main` checkout is fully green, and stays green with the update applied (run locally on Node 22; CI runs Node 25):
- `npm run check` (biome) ✅
- `npm run build` (tsc + vite) ✅
- `npm run test:ci` (vitest, 128 tests) ✅

No new failures.

---

## Pending queue (other outdated dependencies)

None are security-motivated per `npm audit` (see below). Ordered minor → patch:

**Minor**
| Package | Current | Latest |
|---|---|---|
| `@biomejs/biome` | 2.4.15 | 2.5.4 |
| `@tanstack/react-query` | 5.100.14 | 5.101.2 |
| `@tanstack/react-query-persist-client` | 5.100.14 | 5.101.2 |
| `lint-staged` | 17.0.5 | 17.1.0 |
| `terser` | 5.48.0 | 5.49.0 |

> Note: the two `@tanstack/react-query*` packages are a lockstep family and should move together in a single follow-up PR.

**Patch**
| Package | Current | Latest |
|---|---|---|
| `@types/node` | 25.9.1 | 25.9.5 |
| `@types/react` | 19.2.15 | 19.2.17 |
| `@vitejs/plugin-react` | 6.0.2 | 6.0.3 |
| `react` | 19.2.6 | 19.2.7 |
| `react-dom` | 19.2.6 | 19.2.7 |
| `vite` | 8.1.4 | 8.1.5 |
| `vite-plugin-dts` | 5.0.1 | 5.0.3 |

> `react` + `react-dom` are a required-lockstep pair (bundle together in one PR).

---

## Deferred majors (need a human to schedule)

| Package | Current | Latest | Breaking-change note |
|---|---|---|---|
| `typescript` | 6.0.3 | 7.0.2 | Major TS release — new compiler behavior/flags; requires a compile pass across the codebase before adopting. |
| `@types/node` | 25.9.1 | 26.1.1 | Tracks Node 26 typings; adopt alongside a Node runtime bump (CI currently pins Node 25). A patch bump to 25.9.5 is available within the current major (listed above). |

---

## Needs manual attention (security advisories not fixable via a single clean top-level update)

`npm audit` reports 8 advisories (2 high, 5 moderate, 1 low), **all in devDependency transitive chains** — none ship in the published `dist`:

| Severity | Package | Path | Why not fixed here |
|---|---|---|---|
| high | `undici` | `jsdom@29.1.1` (latest) + `semantic-release` | `jsdom` is already at its latest version; no top-level bump resolves the bundled `undici@7.25.0`. |
| high | `sigstore` | `semantic-release → @semantic-release/npm → npm@11.15.0` | Bundled inside `npm`; bumping `semantic-release` to 25.0.8 does **not** change the resolved `npm`/`sigstore` version. |
| moderate | `@sigstore/core`, `@sigstore/verify`, `tar`, `npm` | same bundled-`npm` chain | Same as above. |
| moderate | `js-yaml` | `semantic-release → cosmiconfig → js-yaml@4.1.1` | Still resolves to 4.1.1 after the semantic-release bump. |
| low | `@babel/core` | `@rolldown/plugin-babel@0.2.3` (latest) | Plugin is at its latest release; bundles `@babel/core@7.29.0`. |

These would require nested `npm audit fix` overrides touching many dev-only transitive packages at once, which is outside the one-clean-update-per-PR scope. They are dev/CI-tooling only and do not affect consumers of the library. Left for a human to decide whether to add targeted `overrides`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014wdZXNMqZsAd8LVvQk2E6w)_