### PR TITLE
test: consolidate duplicated live-query test helpers

### DIFF
--- a/src/lib/queries/useQuery$.reactivity.test.tsx
+++ b/src/lib/queries/useQuery$.reactivity.test.tsx
@@ -1,41 +1,14 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { act, render, screen } from "@testing-library/react"
-import type React from "react"
 import { BehaviorSubject, filter, map, switchMap } from "rxjs"
 import { describe, expect, it } from "vitest"
+import {
+  createQueryClient,
+  createWrapper,
+  isDefined,
+  liveQueryOptions,
+} from "../../tests/liveQuery"
 import { waitForTimeout } from "../../tests/utils"
-import { QueryClientProvider$ } from "./QueryClientProvider$"
 import { useQuery$ } from "./useQuery$"
-
-function isDefined<T>(value: T | undefined | null): value is T {
-  return value != null
-}
-
-function createQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        gcTime: 0,
-      },
-    },
-  })
-}
-
-const liveQueryOptions = {
-  networkMode: "always" as const,
-  gcTime: 0,
-  staleTime: Number.POSITIVE_INFINITY,
-}
-
-function createWrapper(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <QueryClientProvider$>{children}</QueryClientProvider$>
-      </QueryClientProvider>
-    )
-  }
-}
 
 describe("useQuery$ live-query reactivity", () => {
   it("re-renders when a new item is added", async () => {

--- a/src/lib/queries/useQuery$.unmount.test.tsx
+++ b/src/lib/queries/useQuery$.unmount.test.tsx
@@ -1,42 +1,15 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { act, render, screen } from "@testing-library/react"
-import type React from "react"
 import { useState } from "react"
 import { BehaviorSubject, filter, map, switchMap } from "rxjs"
 import { describe, expect, it } from "vitest"
+import {
+  createQueryClient,
+  createWrapper,
+  isDefined,
+  liveQueryOptions,
+} from "../../tests/liveQuery"
 import { waitForTimeout } from "../../tests/utils"
-import { QueryClientProvider$ } from "./QueryClientProvider$"
 import { useQuery$ } from "./useQuery$"
-
-function isDefined<T>(value: T | undefined | null): value is T {
-  return value != null
-}
-
-function createQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        gcTime: 0,
-      },
-    },
-  })
-}
-
-const liveQueryOptions = {
-  networkMode: "always" as const,
-  gcTime: 0,
-  staleTime: Number.POSITIVE_INFINITY,
-}
-
-function createWrapper(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <QueryClientProvider$>{children}</QueryClientProvider$>
-      </QueryClientProvider>
-    )
-  }
-}
 
 describe("useQuery$ unmount / remount", () => {
   it("stays reactive after hide/show then adding an item", {

--- a/src/tests/liveQuery.tsx
+++ b/src/tests/liveQuery.tsx
@@ -1,0 +1,33 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type React from "react"
+import { QueryClientProvider$ } from "../lib/queries/QueryClientProvider$"
+
+export function isDefined<T>(value: T | undefined | null): value is T {
+  return value != null
+}
+
+export function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: 0,
+      },
+    },
+  })
+}
+
+export const liveQueryOptions = {
+  networkMode: "always" as const,
+  gcTime: 0,
+  staleTime: Number.POSITIVE_INFINITY,
+}
+
+export function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <QueryClientProvider$>{children}</QueryClientProvider$>
+      </QueryClientProvider>
+    )
+  }
+}


### PR DESCRIPTION
## Live-query test helpers

**What was duplicated.** `src/lib/queries/useQuery$.reactivity.test.tsx` and `src/lib/queries/useQuery$.unmount.test.tsx` each carried a byte-identical 38-line preamble before their `describe` block:

- `isDefined<T>()` — narrowing guard
- `createQueryClient()` — a `QueryClient` with `gcTime: 0`
- `liveQueryOptions` — the `{ networkMode: "always", gcTime: 0, staleTime: Infinity }` option block
- `createWrapper(queryClient)` — the `QueryClientProvider` / `QueryClientProvider$` wrapper

This was the single largest clone flagged by `jscpd` (a 38-line exact match between the two files).

**What it became.** The four helpers now live in a new shared module `src/tests/liveQuery.tsx` (next to the existing `src/tests/utils.tsx`), imported by both specs. The code is moved **verbatim** — same `QueryClient` config, same option values, same wrapper JSX — so behavior is unchanged. The now-unused `@tanstack/react-query`, `react` type, and `QueryClientProvider$` imports were dropped from both specs (the repo compiles with `noUnusedLocals`).

**Net LOC delta:** +45 / −66 = **−21 lines**.

**Why these are truly the same concept.** The two blocks are byte-for-byte identical (verified with `diff`), not merely similar — they are the shared scaffolding for the live-query `useQuery$` specs. Only these two files defined these helpers; the other query specs use genuinely different inline setups (plain `new QueryClient()`, `PersistQueryClientProvider`, custom `client` props), so they were intentionally left untouched rather than force-fitted.

## Gates

Run locally against a clean baseline (both before and after — identical results):

- `npm run check` (biome) ✓
- `npm run build` (tsc + vite) ✓
- `npm run test:ci` — 22 files / 128 tests passing ✓

## Other candidates seen (deferred)

While sweeping I noted a `typeof x === "function" ? x(arg) : x` "resolve an Observable-or-factory source" idiom repeated in `useMutation$`, `useSwitchMutation$`, `useConcatMutation$`, `createObservableQueryFn`, and `useObserve/store`. It's genuinely one concept, but a shared helper comes out roughly LOC-neutral there, so it's left for a future pass rather than bundled into this story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7gH7fnCjWFBRgC15JrYtA)_