### PR TITLE
fix: resolve switch mutations with null when the stream completes empty

### DIFF
--- a/src/lib/queries/useSwitchMutation$.test.tsx
+++ b/src/lib/queries/useSwitchMutation$.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent } from "@testing-library/dom"
 import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import { act, useState } from "react"
-import { delay, finalize, map, of, timer } from "rxjs"
+import { delay, EMPTY, finalize, map, of, timer } from "rxjs"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { waitForTimeout } from "../../tests/utils"
 import { QueryClientProvider$ } from "./QueryClientProvider$"
@@ -277,5 +277,59 @@ describe("useSwitchMutation$", () => {
 
     // The long-running mutations should not have called onSuccess with data
     expect(successSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("should resolve with null when the mutation stream completes without emitting", async () => {
+    const onSuccess = vi.fn()
+    let mutateAsyncResult: Promise<string | null> | undefined
+
+    const TestComponent = () => {
+      "use no memo"
+
+      const { mutateAsync } = useSwitchMutation$<string, Error, string>({
+        mutationFn: () => EMPTY,
+        onSuccess,
+      })
+
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            mutateAsyncResult = mutateAsync("test")
+          }}
+        >
+          Trigger Mutation
+        </button>
+      )
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <QueryClientProvider$>
+          <TestComponent />
+        </QueryClientProvider$>
+      </QueryClientProvider>,
+    )
+
+    act(() => {
+      fireEvent.click(screen.getByText("Trigger Mutation"))
+    })
+
+    const pendingSentinel = Symbol("pending")
+
+    // the promise must settle on its own (with null), not hang until
+    // a subsequent mutation aborts it
+    await waitFor(async () => {
+      expect(
+        await Promise.race([
+          mutateAsyncResult,
+          Promise.resolve(pendingSentinel),
+        ]),
+      ).toBe(null)
+    })
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess.mock.calls[0]?.[0]).toBe(null)
+    expect(onSuccess.mock.calls[0]?.[1]).toBe("test")
   })
 })

--- a/src/lib/queries/useSwitchMutation$.ts
+++ b/src/lib/queries/useSwitchMutation$.ts
@@ -61,15 +61,21 @@ export function useSwitchMutation$<
               ? mutationFn(variables)
               : mutationFn
 
+          /**
+           * `defaultIfEmpty` must sit on the source itself: the abort stream
+           * never completes, so the merged stream never completes either and
+           * a `defaultIfEmpty` placed after it would never fire — an empty
+           * source would leave the mutation pending forever.
+           */
           return merge(
-            source,
+            source.pipe(defaultIfEmpty(null)),
             fromEvent(abort, "abort").pipe(
               tap(() => {
                 throw new SwitchMutationCancelError()
               }),
               ignoreElements(),
             ),
-          ).pipe(first(), defaultIfEmpty(null))
+          ).pipe(first())
         },
         [mutationFn],
       ),


### PR DESCRIPTION
## The bug

When a mutation observable passed to `useSwitchMutation$` completes without emitting any value (e.g. `EMPTY`, or a filtered stream), the mutation never settles: `mutateAsync` hangs forever and `isPending` stays `true` until a *subsequent* mutation aborts it with a `SwitchMutationCancelError`.

Observable with:

```tsx
const { mutateAsync } = useSwitchMutation$({ mutationFn: () => EMPTY })
await mutateAsync() // never resolves, never rejects
```

## Root cause

`useSwitchMutation$` builds its stream as:

```ts
merge(
  source,
  fromEvent(abort, "abort").pipe(tap(throwCancel), ignoreElements()),
).pipe(first(), defaultIfEmpty(null))
```

`fromEvent(signal, "abort")` never completes, so `merge()` never completes when `source` completes empty. The completion never reaches `first()`, and `defaultIfEmpty(null)` — whose whole purpose is to map an empty mutation to `null` (the result type is `TData | null` for exactly this reason) — is unreachable dead code. The bug has been present since the hook was introduced (2cb1d4f).

## The fix

Move `defaultIfEmpty(null)` onto the source itself, so an empty source emits `null` at its own completion and `first()` resolves the mutation. Abort/switch semantics are unchanged: a value (or the injected `null`) still races the abort event through `first()`.

## Verification

New regression test `should resolve with null when the mutation stream completes without emitting` in `useSwitchMutation$.test.tsx`:

- **Before the fix**: the test times out — the `mutateAsync` promise never settles (also reproduced the hang with a standalone RxJS script).
- **After the fix**: the promise resolves with `null`, `onSuccess` receives `(null, variables)`, and all 4 tests in the file pass.

Full gates on the branch: `npm run check` clean, `npm run build` (tsc + vite) succeeds, `npm run test:ci` 129/129 passing.

## Other findings (not addressed in this PR)

- `useQuery$.test.tsx > "should return consecutive results"` is flaky under full-suite load on clean `main` (times out at 500 ms when run with the whole suite, passes in isolation and on re-runs). Worth a look at the test timeout or cross-file resource contention.
- `ObservableStore.subscribe` (`src/lib/binding/useObserve/store.ts`) guards against re-subscribing a *completed* source but not an *errored* one; since `share()` resets on error, the `useSyncExternalStore` subscribe re-executes the source observable (duplicating its side effects, e.g. a fetch) after a synchronous error. Not demonstrated end-to-end in a React test, so left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWPsHcRZtDAUYGsBEihBgh)_