### PR TITLE
chore: upgrade @types/node to 25.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@tanstack/react-query-persist-client": "^5.96.2",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^16.1.0",
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.5",
         "@types/react": "^19.0.2",
         "@types/react-dom": "^19.0.2",
         "@vitejs/plugin-react": "^6.0.2",
@@ -1836,9 +1836,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@tanstack/react-query-persist-client": "^5.96.2",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^16.1.0",
-    "@types/node": "^25.9.1",
+    "@types/node": "^25.9.5",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^6.0.2",


### PR DESCRIPTION
## The update

| Package | Old | New | Type |
| --- | --- | --- | --- |
| `@types/node` | 25.9.1 | 25.9.5 | patch (within existing `^25` range) |

Type-only dev dependency (TypeScript definitions for Node). Picked as the most-behind patch update available (4 patch releases behind) after determining that no security advisory could be resolved by a single direct-dependency bump — see below.

**Gates** (matching CI: `check` → `build` → `test:ci`), baseline recorded on a clean `main` checkout first:

| Gate | Baseline | With update |
| --- | --- | --- |
| `npm run check` (biome) | clean | clean |
| `npm run build` (tsc + vite) | ✓ | ✓ |
| `npm run test:ci` (vitest) | 129 passed | 129 passed |

No new failures.

## Pending queue (other outdated deps, by update type)

Patch (within range):
- `@types/react` 19.2.15 → 19.2.17
- `@vitejs/plugin-react` 6.0.2 → 6.0.3
- `react` 19.2.6 → 19.2.7  ·  `react-dom` 19.2.6 → 19.2.7 (must move together — React family released in lockstep)
- `vite-plugin-dts` 5.0.1 → 5.0.3
- `vite` 8.1.4 → 8.1.5 — already covered by Dependabot #140

Minor (within range):
- `@tanstack/react-query` 5.100.14 → 5.101.2  ·  `@tanstack/react-query-persist-client` 5.100.14 → 5.101.2 (same scoped family; should move together)
- `terser` 5.48.0 → 5.49.0
- `lint-staged` 17.0.5 → 17.1.0 — already covered by Dependabot #141

## Deferred majors (need a human to schedule)

- `typescript` 6.0.3 → **7.0.2** — major TS release; likely new/changed diagnostics and possible breaking type-checking behavior. Review changelog before adopting.
- `@types/node` 25.9.5 → **26.1.1** — targets a newer Node major; out of scope for this patch bump (CI pins Node 25).
- `@biomejs/biome` 2.4.15 → 2.5.4 (minor) — **pinned to an exact version** in `package.json`; treated as deliberate intent and left untouched.

## Security advisories (informational — none fixed here)

`npm audit` reports 8 advisories (1 low, 5 moderate, 2 high). All are **transitive, dev/release-only** dependencies pulled in by `semantic-release@25.0.8` (already the latest release) and its bundled `npm`, so none can be resolved by bumping a single direct dependency, and `npm audit fix` (without `--force`) resolves zero of them:

- **high** `sigstore` ≤4.1.0 — certificateOIDs constraints silently dropped (GHSA-52v5-jr5w-gjxr) — via bundled `npm` → `libnpmpublish`
- **high** `undici` — multiple advisories (TLS bypass, header injection, DoS…) — via `@actions/http-client` (semantic-release) and bundled `npm`
- **moderate** `@sigstore/core` ≤3.2.0 (GHSA-jfc7-64v2-mr8c), `@sigstore/verify` 3.1.0 (GHSA-xgjw-pm74-86q4), `js-yaml` 4.0.0–4.1.1 (GHSA-h67p-54hq-rp68), `tar` ≤7.5.15 (GHSA-vmf3-w455-68vh)
- **low** `@babel/core` ≤7.29.0 — sourceMappingURL arbitrary file read (GHSA-4x5r-pxfx-6jf8)

These will clear when `semantic-release` ships a release bundling patched transitive versions. No forced major bumps were applied.

## Needs manual attention

None — the chosen update broke no gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmfK8vFU5qrMtmMzSJw2mo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmfK8vFU5qrMtmMzSJw2mo)_