### PR TITLE
fix: detect non-native thenables in isPromiseLike

### DIFF
--- a/src/lib/utils/isPromiseLike.test.ts
+++ b/src/lib/utils/isPromiseLike.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { isPromiseLike } from "./isPromiseLike"
+import { makeObservable } from "./makeObservable"
+
+const createThenable = (value: number) => ({
+  // biome-ignore lint/suspicious/noThenProperty: intentionally building a non-native thenable
+  then(onFulfilled: (value: number) => void) {
+    onFulfilled(value)
+
+    return this
+  },
+  catch() {
+    return this
+  },
+})
+
+describe("isPromiseLike", () => {
+  it("returns true for a native promise", () => {
+    expect(isPromiseLike(Promise.resolve(1))).toBe(true)
+  })
+
+  it("returns true for a non-native thenable with then and catch functions", () => {
+    expect(isPromiseLike(createThenable(42))).toBe(true)
+  })
+
+  it("returns false for an object whose catch is not a function", () => {
+    const notAPromise = {
+      // biome-ignore lint/suspicious/noThenProperty: intentionally testing a fake thenable
+      then: () => {},
+      catch: "function",
+    }
+
+    expect(isPromiseLike(notAPromise)).toBe(false)
+  })
+
+  it("returns falsy for non promise values", () => {
+    expect(isPromiseLike(undefined)).toBeFalsy()
+    expect(isPromiseLike(null)).toBeFalsy()
+    expect(isPromiseLike(42)).toBeFalsy()
+    expect(isPromiseLike({})).toBeFalsy()
+    expect(isPromiseLike(() => {})).toBeFalsy()
+  })
+
+  it("makes makeObservable emit the resolved value of a thenable, not the thenable itself", () => {
+    const thenable = createThenable(42)
+
+    const emitted: unknown[] = []
+
+    makeObservable(thenable)().subscribe((value) => {
+      emitted.push(value)
+    })
+
+    expect(emitted).toEqual([42])
+  })
+})

--- a/src/lib/utils/isPromiseLike.ts
+++ b/src/lib/utils/isPromiseLike.ts
@@ -7,6 +7,6 @@ export function isPromiseLike<T>(value: T): value is T & Promise<any> {
       "then" in value &&
       typeof value.then === "function" &&
       "catch" in value &&
-      value.catch === "function")
+      typeof value.catch === "function")
   )
 }


### PR DESCRIPTION
## The bug

`isPromiseLike` (`src/lib/utils/isPromiseLike.ts`) ended with:

```ts
"catch" in value &&
value.catch === "function"
```

The `typeof` is missing, so the last condition compares the `catch` **method itself** to the string `"function"` — which is always false for a real thenable. The whole structural branch is therefore dead code, and `isPromiseLike` only ever returns true for `value instanceof Promise`.

## How to observe it

Any promise-like value that is not a native `Promise` instance (a cross-realm promise, a polyfill, or a lazy thenable such as an ORM query object) is misclassified as plain data. `makeObservable` — which backs the public `useSubscribe` and `useSubscribeEffect` hooks and is itself exported — then wraps the thenable in `of(...)` instead of `from(...)`, so subscribers receive the **raw thenable object** instead of its resolved value:

```ts
const thenable = { then: (resolve) => resolve(42), catch: () => {} }
makeObservable(thenable)().subscribe(console.log)
// before: logs the thenable object itself
// after:  logs 42
```

As a bonus, the buggy comparison also returned `true` for a nonsense object like `{ then: () => {}, catch: "function" }` (where `catch` is literally the string `"function"`).

## The fix

One-character-class fix: `value.catch === "function"` → `typeof value.catch === "function"`. No other behavior changed.

## Verification

- New regression suite `src/lib/utils/isPromiseLike.test.ts`: 3 of 5 tests fail on the previous code (thenable detection, the string-`catch` false positive, and the `makeObservable` integration emitting the raw thenable) and all pass after the fix.
- Baseline before the fix: 22 files / 129 tests green. After the fix: 23 files / 134 tests green, `npm run check` (biome) clean, `npm run build` (tsc + vite) clean — the same gates CI runs.

## Other findings (not addressed in this PR)

- `usePersistSignals` pipes `entriesSubject` through `concatMap(persistSignals)`, but the inner persistence stream never completes, so a *changed* `entries` array is queued forever and never hydrated/persisted. The hook's docs say a new entries reference "will start over the process once the current one is finished", so this may be a known design trade-off; flagging it since the restart can never actually happen while an adapter is active.
- `ObservableStore.subscribe` (`useObserve`) re-subscribes the shared source after a synchronous error: `share()` resets on error, so the underlying cold observable's side effects execute a second time when React attaches its `useSyncExternalStore` subscriber. Not fixed here because the observable state semantics around errors look intentional and the blast radius of changing it is larger.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xfhen71E1NXj61srsKLaY)_