### PR TITLE
test: dedupe isDefined helper against the library util

### DIFF
--- a/src/lib/queries/useQuery$.reactivity.test.tsx
+++ b/src/lib/queries/useQuery$.reactivity.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it } from "vitest"
 import {
   createQueryClient,
   createWrapper,
-  isDefined,
   liveQueryOptions,
 } from "../../tests/liveQuery"
 import { waitForTimeout } from "../../tests/utils"
+import { isDefined } from "../utils/isDefined"
 import { useQuery$ } from "./useQuery$"
 
 describe("useQuery$ live-query reactivity", () => {

--- a/src/lib/queries/useQuery$.unmount.test.tsx
+++ b/src/lib/queries/useQuery$.unmount.test.tsx
@@ -5,10 +5,10 @@ import { describe, expect, it } from "vitest"
 import {
   createQueryClient,
   createWrapper,
-  isDefined,
   liveQueryOptions,
 } from "../../tests/liveQuery"
 import { waitForTimeout } from "../../tests/utils"
+import { isDefined } from "../utils/isDefined"
 import { useQuery$ } from "./useQuery$"
 
 describe("useQuery$ unmount / remount", () => {

--- a/src/tests/liveQuery.tsx
+++ b/src/tests/liveQuery.tsx
@@ -2,10 +2,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type React from "react"
 import { QueryClientProvider$ } from "../lib/queries/QueryClientProvider$"
 
-export function isDefined<T>(value: T | undefined | null): value is T {
-  return value != null
-}
-
 export function createQueryClient() {
   return new QueryClient({
     defaultOptions: {


### PR DESCRIPTION
## Summary

`src/tests/liveQuery.tsx` defined its own `isDefined` type-guard:

```ts
export function isDefined<T>(value: T | undefined | null): value is T {
  return value != null
}
```

This is a runtime-identical copy of the shipped `src/lib/utils/isDefined.ts`. The two live-query test suites now import `isDefined` from the library util directly, and the local copy is deleted — one implementation instead of two.

Behavior-preserving: the query pipes and assertions are unchanged; only the source of `isDefined` moved.

## Net LOC

`2 insertions, 6 deletions` → net −4 lines across 3 files.

## Note

An earlier revision of this PR also extracted the repeated live-query `queryFn` pipe into a `createLiveQueryFn` factory in the shared test helper. That was reverted — a test-only closure factory living in the source tree wasn't a good trade, so the inline pipes are left as-is.

## Gates

All green locally: biome `check`, `tsc`, `vite build`, `vitest run` (129 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)