### PR TITLE
chore: dead-code sweep 2026-07-27 — drop unused export modifier on SubscribeSourceFactory

### DIFF
--- a/src/lib/binding/useSubscribe/types.ts
+++ b/src/lib/binding/useSubscribe/types.ts
@@ -1,6 +1,6 @@
 import type { Observable } from "rxjs"
 
-export type SubscribeSourceFactory<Data> =
+type SubscribeSourceFactory<Data> =
   | (() => Observable<Data>)
   | (() => Observable<Data> | undefined)
   | (() => Promise<Data>)


### PR DESCRIPTION
Automated strict dead-code sweep (knip over library + dev entries, plus a production-entries-only pass, every candidate verified by repo-wide grep).

## Removed

- **`export` modifier on `SubscribeSourceFactory`** (`src/lib/binding/useSubscribe/types.ts`) — the type itself is live (used by `SubscribeSource` in the same file), but the export was dead surface. Evidence: repo-wide grep for `SubscribeSourceFactory` matches only its own declaration and the same-file `SubscribeSource` reference; `src/lib/binding/useSubscribe/index.ts` re-exports only `./useSubscribe`, not `./types`, so the type never reaches the package's public API via `src/index.ts`.

## Candidates investigated and kept

- `src/lib/state/persistence/adapters/MockAdapter.ts` — flagged unused in production-only analysis, but it is live test infrastructure imported by `persistSignals.test.ts`.
- `src/lib/utils/filterObjectByKey.ts` — same situation: imported by `useObserve.selector.test.tsx` as a test helper.

No unused files, no unused package dependencies found. Public API exported through `src/index.ts` was treated as off-limits (published npm package).

## Gates

Baseline on clean `main` and after the change, both fully green:
- `npm run check` (biome) ✓
- `npm run build` (tsc + vite) ✓
- `npm run test:ci` — 23 files, 134 tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9ch8GmdfsE2RPy8adBGPo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9ch8GmdfsE2RPy8adBGPo)_