### PR TITLE
fix: subscribe useObservableState to its subject so setState re-renders

### DIFF
--- a/src/lib/binding/useObservableState.test.tsx
+++ b/src/lib/binding/useObservableState.test.tsx
@@ -1,0 +1,65 @@
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { useObservableState } from "./useObservableState"
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("useObservableState", () => {
+  it("should return the default value on first render", () => {
+    const { result } = renderHook(() => useObservableState(5))
+
+    expect(result.current[0]).toBe(5)
+    expect(result.current[2].getValue()).toBe(5)
+  })
+
+  it("should re-render with the new value when setState is called", () => {
+    const { result } = renderHook(() => useObservableState(0))
+
+    act(() => {
+      result.current[1](1)
+    })
+
+    expect(result.current[0]).toBe(1)
+  })
+
+  it("should re-render with the new value when setState is called with an updater", () => {
+    const { result } = renderHook(() => useObservableState(1))
+
+    act(() => {
+      result.current[1]((prev) => prev + 1)
+    })
+
+    expect(result.current[0]).toBe(2)
+  })
+
+  it("should re-render when the subject is updated directly", () => {
+    const { result } = renderHook(() => useObservableState(0))
+
+    act(() => {
+      result.current[2].next(10)
+    })
+
+    expect(result.current[0]).toBe(10)
+  })
+
+  it("should not re-render when setState is called with the current value", () => {
+    let renderCount = 0
+
+    const { result } = renderHook(() => {
+      renderCount++
+
+      return useObservableState(0)
+    })
+
+    const renderCountAfterMount = renderCount
+
+    act(() => {
+      result.current[1](0)
+    })
+
+    expect(result.current[0]).toBe(0)
+    expect(renderCount).toBe(renderCountAfterMount)
+  })
+})

--- a/src/lib/binding/useObservableState.ts
+++ b/src/lib/binding/useObservableState.ts
@@ -1,5 +1,10 @@
-import { type Dispatch, type SetStateAction, useCallback } from "react"
-import { BehaviorSubject } from "rxjs"
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useSyncExternalStore,
+} from "react"
+import { BehaviorSubject, skip } from "rxjs"
 import { useConstant } from "../utils/react/useConstant"
 
 export const useObservableState = <T>(
@@ -29,7 +34,26 @@ export const useObservableState = <T>(
     [subject],
   )
 
-  const value = subject.getValue()
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      /**
+       * `BehaviorSubject` synchronously replays its current value to new
+       * subscribers while `useSyncExternalStore` reads the initial value
+       * through `getSnapshot`, so the first emission is skipped to only
+       * notify React about actual changes.
+       */
+      const sub = subject.pipe(skip(1)).subscribe(onChange)
+
+      return () => {
+        sub.unsubscribe()
+      }
+    },
+    [subject],
+  )
+
+  const getSnapshot = useCallback(() => subject.getValue(), [subject])
+
+  const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 
   return [value, setState, subject]
 }


### PR DESCRIPTION
## Bug

`useObservableState` (publicly exported from the package root) returns `[value, setState, subject]`, mirroring `React.useState` — its setter is even typed as `Dispatch<SetStateAction<T>>`. But calling `setState` never triggers a re-render: the component keeps rendering the stale initial value forever.

How to observe:

```tsx
const [value, setState] = useObservableState(0)
// setState(1) → subject.next(1) fires, but `value` stays 0 on screen
```

## Root cause

The hook only pushed values into its internal `BehaviorSubject` (`subject.next(...)`) and read `subject.getValue()` once during render. Nothing subscribed the subject back to React, so React had no reason to re-render — the returned `value` was a one-shot snapshot from mount. (The pre-rewrite version of this hook returned the observable itself, so consumers subscribed on their own; the rewrite in `abfbbbb` changed the contract to `useState` parity but never added the subscription.)

## Fix

Wire the subject to React with `useSyncExternalStore`, following the same pattern the library already uses in `useSignalValue`: subscribe with `skip(1)` (a `BehaviorSubject` synchronously replays its current value, while `useSyncExternalStore` reads the initial value through `getSnapshot`), and use `subject.getValue()` as the snapshot. This also makes the hook re-render on direct `subject.next()` calls from outside the hook, which the returned subject explicitly invites.

## Verification

Added `src/lib/binding/useObservableState.test.tsx` (the hook previously had no tests). Before the fix, 3 of the 5 tests fail on `main`:

- ❌ → ✅ re-render when `setState` is called with a value
- ❌ → ✅ re-render when `setState` is called with an updater function
- ❌ → ✅ re-render when the subject is updated directly
- ✅ default value on first render (already passing)
- ✅ no re-render when `setState` receives the current value (already passing)

Full gates pass after the fix: `npm run check` (biome), `npm run build` (tsc + vite), `npm run test:ci` — 24 files / 139 tests green.

## Other findings (not addressed in this PR)

- `signal({ default: null })` yields a signal whose value is `undefined`, not `null`, despite being typed `Signal<null>`: the factory in `src/lib/state/Signal.ts` builds the config with `default: config.default ?? undefined`, and `??` coerces an explicit `null` default to `undefined`. Verified by tracing the exact expression: `{ ...{ default: null }, default: null ?? undefined }` → `default: undefined`. Also affects `SIGNAL_RESET`, which resets to `undefined` instead of the declared `null` default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHTuazpMJYhEVqdtuVWvz9)_