### PR TITLE
chore: upgrade transitive npm to 11.18.0 for tar security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4996,9 +4996,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.15.0.tgz",
-      "integrity": "sha512-+k0tk7lRnpMUPnC7kTuU/yrV/mnFoPhJQ75VfLtZ6fwbzOVXaPsTE/Il9Pn1DHi482byMyqkHv/XsQ76mNjXLw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -5077,8 +5077,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.6.0",
-        "@npmcli/config": "^10.9.1",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -5102,40 +5102,40 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.8",
-        "libnpmexec": "^10.2.8",
-        "libnpmfund": "^7.0.22",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.8",
+        "libnpmpack": "^9.1.11",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
         "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.3.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.15",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -5208,7 +5208,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5224,7 +5224,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.6.0",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5272,7 +5272,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.9.1",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5466,7 +5466,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -5514,13 +5514,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -5617,7 +5617,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5991,12 +5991,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.8",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.6.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -6010,13 +6010,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.8",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.6.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -6033,12 +6033,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.22",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.6.0"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6058,12 +6058,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.8",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.6.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -6117,7 +6117,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6133,7 +6133,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.5.0",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -6142,7 +6142,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6308,7 +6308,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.3.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6432,13 +6432,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6485,7 +6485,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6546,7 +6546,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6643,7 +6643,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.0",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6667,17 +6667,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6768,7 +6768,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.15",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -6796,7 +6796,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6864,7 +6864,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.25.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",


### PR DESCRIPTION
## The update

**npm (transitive, via `@semantic-release/npm`): 11.15.0 → 11.18.0** — lockfile-only, security-motivated. No manifest change; the bump stays inside the existing `^11.6.2` range declared by `@semantic-release/npm`.

npm bundles its own copy of `node-tar`, and the copy shipped in 11.15.0 (tar 7.5.15) was flagged by several advisories. Upgrading to npm 11.18.0 moves the bundled tar to 7.5.19, which resolves:

- **GHSA-23hp-3jrh-7fpw (critical)** — node-tar decompression/parse DoS via unlimited input
- **GHSA-8x88-c5mf-7j5w (high)** — negative tar entry size causes infinite loop in archive replace
- GHSA-vmf3-w455-68vh (moderate) — PAX size override parser differential (file smuggling)
- GHSA-w8wr-v893-vjvp (moderate) — process crash via PAX numeric path type confusion
- GHSA-gvwx-54wh-qm9j (moderate) — uncaught exception DoS via NUL byte in PAX records

Because tar is *bundled* inside the npm package, updating tar alone cannot fix these — npm itself has to move, which is why the two are coupled (this shows in the lockfile as the `node_modules/npm` subtree refresh).

Gates (`npm run check`, `npm run build`, `npm run test:ci`) pass with no new failures: 91 files lint-clean, build green, 23 test files / 134 tests passed. (Verified on Node 22 — the environment had no Node 25 runtime; CI will confirm on the pinned Node 25.)

## Pending queue (found this run, one PR each in future runs)

Security (transitive, lockfile-fixable via `npm audit fix`):
- **undici** ≤7.27.2 (high) — via `jsdom`, `@semantic-release/github`, `@actions/http-client`
- **js-yaml** 4.0.0–4.2.0 (high) — via `cosmiconfig`
- **brace-expansion** ≤5.0.7 (high) — via `minimatch`
- **sigstore / @sigstore/core / @sigstore/verify** (moderate) — via npm toolchain
- **@babel/core** ≤7.29.0 (low)

Patch:
- @types/react 19.2.15 → 19.2.17
- @vitejs/plugin-react 6.0.2 → 6.0.4
- react / react-dom 19.2.6 → 19.2.8 (lockstep pair)
- vite 8.1.4 → 8.1.5
- vite-plugin-dts 5.0.1 → 5.0.3

Minor:
- @tanstack/react-query + @tanstack/react-query-persist-client 5.100.14 → 5.101.4 (lockstep pair)
- lint-staged 17.0.5 → 17.2.0
- terser 5.48.0 → 5.49.0
- @biomejs/biome 2.4.15 → 2.5.5 — *exact pin*, treated as deliberate; will need an explicit manifest bump

Major (breaking — still coming, one at a time):
- @testing-library/jest-dom 6.9.1 → **7.0.0**
- @types/node 25.9.5 → **26.1.1**
- jsdom 29.1.1 → **30.0.0**
- typescript 6.0.3 → **7.0.2**

## Needs manual attention

- **tar GHSA-r292-9mhp-454m (moderate)** remains after this bump: it needs tar > 7.5.20, but the latest npm 11.x (11.18.0) still bundles 7.5.19, and bundled deps can't be overridden from this repo's lockfile. It will clear when a future npm release bundles a fixed tar; `npm audit`'s only suggested "fix" today is a nonsensical major downgrade of semantic-release to 15.9.3, which I did not take.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9LXAqSmGWMsik6okLkRAe)_