### PR TITLE
test: consolidate duplicated live-query test harness

### DIFF
--- a/src/lib/queries/useQuery$.reactivity.test.tsx
+++ b/src/lib/queries/useQuery$.reactivity.test.tsx
@@ -1,111 +1,89 @@
+import type { NetworkMode } from "@tanstack/react-query"
 import { act, render, screen } from "@testing-library/react"
-import { BehaviorSubject, filter, map, switchMap } from "rxjs"
 import { describe, expect, it } from "vitest"
 import {
+  createLiveQuerySource,
   createQueryClient,
   createWrapper,
   liveQueryOptions,
 } from "../../tests/liveQuery"
 import { waitForTimeout } from "../../tests/utils"
-import { isDefined } from "../utils/isDefined"
 import { useQuery$ } from "./useQuery$"
+
+function setup(
+  queryKey: string[],
+  initialItems: string[],
+  queryOptions: {
+    networkMode?: NetworkMode
+    gcTime?: number
+    staleTime?: number
+  } = liveQueryOptions,
+) {
+  const { liveQuery$, queryFn } = createLiveQuerySource(initialItems)
+  const queryClient = createQueryClient()
+
+  function Comp() {
+    const { data } = useQuery$({
+      ...queryOptions,
+      queryKey,
+      queryFn,
+    })
+
+    return <span data-testid="data">{JSON.stringify(data)}</span>
+  }
+
+  render(<Comp />, { wrapper: createWrapper(queryClient) })
+
+  return { liveQuery$, queryClient }
+}
+
+const expectData = (items: string[]) =>
+  expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(items))
 
 describe("useQuery$ live-query reactivity", () => {
   it("re-renders when a new item is added", async () => {
-    const liveQuery$ = new BehaviorSubject(["a", "b"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function Comp() {
-      const { data } = useQuery$({
-        ...liveQueryOptions,
-        queryKey: ["live", "add"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    render(<Comp />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$ } = setup(["live", "add"], ["a", "b"])
 
     await act(async () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b"]),
-    )
+    expectData(["a", "b"])
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
   })
 
   it("re-renders when an item is removed", async () => {
-    const liveQuery$ = new BehaviorSubject(["a", "b", "c"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function Comp() {
-      const { data } = useQuery$({
-        ...liveQueryOptions,
-        queryKey: ["live", "remove"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    render(<Comp />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$ } = setup(["live", "remove"], ["a", "b", "c"])
 
     await act(async () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
 
     await act(async () => {
       liveQuery$.next(["a", "c"])
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "c"]),
-    )
+    expectData(["a", "c"])
   })
 
   it("re-renders with two observers on the same key", async () => {
-    const liveQuery$ = new BehaviorSubject(["a", "b"])
-    const db$ = new BehaviorSubject<object | undefined>({})
+    const { liveQuery$, queryFn } = createLiveQuerySource(["a", "b"])
     const queryClient = createQueryClient()
 
     function useLive() {
       return useQuery$({
         ...liveQueryOptions,
         queryKey: ["live", "double"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
+        queryFn,
       })
     }
 
@@ -122,47 +100,24 @@ describe("useQuery$ live-query reactivity", () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b"]),
-    )
+    expectData(["a", "b"])
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
   })
 
   it("settles on the latest value after rapid emissions", async () => {
-    const liveQuery$ = new BehaviorSubject(["a"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function Comp() {
-      const { data } = useQuery$({
-        ...liveQueryOptions,
-        queryKey: ["live", "rapid"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    render(<Comp />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$ } = setup(["live", "rapid"], ["a"])
 
     await act(async () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(["a"]))
+    expectData(["a"])
 
     await act(async () => {
       liveQuery$.next(["a", "b"])
@@ -171,33 +126,15 @@ describe("useQuery$ live-query reactivity", () => {
       await waitForTimeout(300)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c", "d"]),
-    )
+    expectData(["a", "b", "c", "d"])
   })
 
   it("survives an external refetch racing with the internal loop", async () => {
-    const liveQuery$ = new BehaviorSubject(["a", "b"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function Comp() {
-      const { data } = useQuery$({
-        networkMode: "always",
-        gcTime: 0,
-        queryKey: ["live", "external-refetch"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    render(<Comp />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$, queryClient } = setup(
+      ["live", "external-refetch"],
+      ["a", "b"],
+      { networkMode: "always", gcTime: 0 },
+    )
 
     await act(async () => {
       await waitForTimeout(100)
@@ -216,33 +153,15 @@ describe("useQuery$ live-query reactivity", () => {
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
   })
 
   it("survives invalidateQueries followed by a data change", async () => {
-    const liveQuery$ = new BehaviorSubject(["a", "b"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function Comp() {
-      const { data } = useQuery$({
-        networkMode: "always",
-        gcTime: 0,
-        queryKey: ["live", "invalidate"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    render(<Comp />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$, queryClient } = setup(
+      ["live", "invalidate"],
+      ["a", "b"],
+      { networkMode: "always", gcTime: 0 },
+    )
 
     await act(async () => {
       await waitForTimeout(100)
@@ -261,8 +180,6 @@ describe("useQuery$ live-query reactivity", () => {
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
   })
 })

--- a/src/lib/queries/useQuery$.unmount.test.tsx
+++ b/src/lib/queries/useQuery$.unmount.test.tsx
@@ -1,57 +1,57 @@
 import { act, render, screen } from "@testing-library/react"
 import { useState } from "react"
-import { BehaviorSubject, filter, map, switchMap } from "rxjs"
 import { describe, expect, it } from "vitest"
 import {
+  createLiveQuerySource,
   createQueryClient,
   createWrapper,
   liveQueryOptions,
 } from "../../tests/liveQuery"
 import { waitForTimeout } from "../../tests/utils"
-import { isDefined } from "../utils/isDefined"
 import { useQuery$ } from "./useQuery$"
+
+function setup(queryKey: string[], initialItems: string[]) {
+  const { liveQuery$, queryFn } = createLiveQuerySource(initialItems)
+  const queryClient = createQueryClient()
+
+  function List() {
+    const { data } = useQuery$({
+      ...liveQueryOptions,
+      queryKey,
+      queryFn,
+    })
+
+    return <span data-testid="data">{JSON.stringify(data)}</span>
+  }
+
+  let toggle = () => {}
+
+  function Host() {
+    const [visible, setVisible] = useState(true)
+    toggle = () => setVisible((v) => !v)
+
+    return visible ? <List /> : <span data-testid="hidden" />
+  }
+
+  render(<Host />, { wrapper: createWrapper(queryClient) })
+
+  return { liveQuery$, toggle: () => toggle() }
+}
+
+const expectData = (items: string[]) =>
+  expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(items))
 
 describe("useQuery$ unmount / remount", () => {
   it("stays reactive after hide/show then adding an item", {
     timeout: 3000,
   }, async () => {
-    const liveQuery$ = new BehaviorSubject(["a", "b"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function List() {
-      const { data } = useQuery$({
-        ...liveQueryOptions,
-        queryKey: ["unmount", "add"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    let toggle: () => void
-
-    function Host() {
-      const [visible, setVisible] = useState(true)
-      toggle = () => setVisible((v) => !v)
-
-      return visible ? <List /> : <span data-testid="hidden" />
-    }
-
-    render(<Host />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$, toggle } = setup(["unmount", "add"], ["a", "b"])
 
     await act(async () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b"]),
-    )
+    expectData(["a", "b"])
 
     await act(async () => {
       toggle()
@@ -59,60 +59,26 @@ describe("useQuery$ unmount / remount", () => {
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b"]),
-    )
+    expectData(["a", "b"])
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c"])
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
   })
 
   it("stays reactive after hide/show then removing an item", {
     timeout: 3000,
   }, async () => {
-    const liveQuery$ = new BehaviorSubject(["a", "b", "c"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function List() {
-      const { data } = useQuery$({
-        ...liveQueryOptions,
-        queryKey: ["unmount", "remove"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    let toggle: () => void
-
-    function Host() {
-      const [visible, setVisible] = useState(true)
-      toggle = () => setVisible((v) => !v)
-
-      return visible ? <List /> : <span data-testid="hidden" />
-    }
-
-    render(<Host />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$, toggle } = setup(["unmount", "remove"], ["a", "b", "c"])
 
     await act(async () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
 
     await act(async () => {
       toggle()
@@ -125,49 +91,19 @@ describe("useQuery$ unmount / remount", () => {
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "c"]),
-    )
+    expectData(["a", "c"])
   })
 
   it("stays reactive after multiple hide/show cycles", {
     timeout: 5000,
   }, async () => {
-    const liveQuery$ = new BehaviorSubject(["a"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function List() {
-      const { data } = useQuery$({
-        ...liveQueryOptions,
-        queryKey: ["unmount", "multi"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    let toggle: () => void
-
-    function Host() {
-      const [visible, setVisible] = useState(true)
-      toggle = () => setVisible((v) => !v)
-
-      return visible ? <List /> : <span data-testid="hidden" />
-    }
-
-    render(<Host />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$, toggle } = setup(["unmount", "multi"], ["a"])
 
     await act(async () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(["a"]))
+    expectData(["a"])
 
     for (let i = 0; i < 5; i++) {
       await act(async () => {
@@ -177,16 +113,14 @@ describe("useQuery$ unmount / remount", () => {
       })
     }
 
-    expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(["a"]))
+    expectData(["a"])
 
     await act(async () => {
       liveQuery$.next(["a", "b"])
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b"]),
-    )
+    expectData(["a", "b"])
   })
 
   /**
@@ -201,50 +135,20 @@ describe("useQuery$ unmount / remount", () => {
   it("does not create orphaned subscriptions when refetch races with hide/show", {
     timeout: 3000,
   }, async () => {
-    const liveQuery$ = new BehaviorSubject(["a"])
-    const db$ = new BehaviorSubject<object | undefined>({})
-    const queryClient = createQueryClient()
-
-    function List() {
-      const { data } = useQuery$({
-        ...liveQueryOptions,
-        queryKey: ["unmount", "stale-guard"],
-        queryFn: () =>
-          db$.pipe(
-            filter(isDefined),
-            switchMap(() => liveQuery$),
-            map((items) => [...items]),
-          ),
-      })
-
-      return <span data-testid="data">{JSON.stringify(data)}</span>
-    }
-
-    let toggle: () => void
-
-    function Host() {
-      const [visible, setVisible] = useState(true)
-      toggle = () => setVisible((v) => !v)
-
-      return visible ? <List /> : <span data-testid="hidden" />
-    }
-
-    render(<Host />, { wrapper: createWrapper(queryClient) })
+    const { liveQuery$, toggle } = setup(["unmount", "stale-guard"], ["a"])
 
     await act(async () => {
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(["a"]))
+    expectData(["a"])
 
     await act(async () => {
       liveQuery$.next(["a", "b"])
       await waitForTimeout(100)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b"]),
-    )
+    expectData(["a", "b"])
 
     liveQuery$.next(["a", "b", "c"])
 
@@ -254,17 +158,13 @@ describe("useQuery$ unmount / remount", () => {
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c"]),
-    )
+    expectData(["a", "b", "c"])
 
     await act(async () => {
       liveQuery$.next(["a", "b", "c", "d"])
       await waitForTimeout(200)
     })
 
-    expect(screen.getByTestId("data").textContent).toBe(
-      JSON.stringify(["a", "b", "c", "d"]),
-    )
+    expectData(["a", "b", "c", "d"])
   })
 })

--- a/src/tests/liveQuery.tsx
+++ b/src/tests/liveQuery.tsx
@@ -1,6 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type React from "react"
+import { BehaviorSubject, filter, map, switchMap } from "rxjs"
 import { QueryClientProvider$ } from "../lib/queries/QueryClientProvider$"
+import { isDefined } from "../lib/utils/isDefined"
 
 export function createQueryClient() {
   return new QueryClient({
@@ -16,6 +18,25 @@ export const liveQueryOptions = {
   networkMode: "always" as const,
   gcTime: 0,
   staleTime: Number.POSITIVE_INFINITY,
+}
+
+/**
+ * Emulates a live query backed by a database: `queryFn` waits for the db to
+ * be ready then emits a fresh copy of the current items whenever `liveQuery$`
+ * pushes a new list.
+ */
+export function createLiveQuerySource(initialItems: string[]) {
+  const liveQuery$ = new BehaviorSubject(initialItems)
+  const db$ = new BehaviorSubject<object | undefined>({})
+
+  const queryFn = () =>
+    db$.pipe(
+      filter(isDefined),
+      switchMap(() => liveQuery$),
+      map((items) => [...items]),
+    )
+
+  return { liveQuery$, queryFn }
 }
 
 export function createWrapper(queryClient: QueryClient) {


### PR DESCRIPTION
## Consolidation: live-query test harness (net −162 LOC)

**What was duplicated**

- `src/lib/queries/useQuery$.reactivity.test.tsx` (6 copies)
- `src/lib/queries/useQuery$.unmount.test.tsx` (4 copies)

Every test in these two suites rebuilt the exact same scaffold by hand:

```tsx
const liveQuery$ = new BehaviorSubject([...])
const db$ = new BehaviorSubject<object | undefined>({})
const queryClient = createQueryClient()

function Comp() {
  const { data } = useQuery$({
    ...liveQueryOptions,
    queryKey: [...],
    queryFn: () =>
      db$.pipe(filter(isDefined), switchMap(() => liveQuery$), map((items) => [...items])),
  })
  return <span data-testid="data">{JSON.stringify(data)}</span>
}

render(<Comp />, { wrapper: createWrapper(queryClient) })
```

plus, in the unmount suite, the same `Host`/`toggle` visibility wrapper repeated in all 4 tests, and the same `expect(screen.getByTestId("data").textContent).toBe(JSON.stringify(...))` assertion everywhere.

**What it became**

- `createLiveQuerySource(initialItems)` in `src/tests/liveQuery.tsx` — the shared home these suites already import from (`createQueryClient`, `createWrapper`, `liveQueryOptions` were consolidated there by #144's follow-ups). It builds the `liveQuery$`/`db$` pair and the `filter → switchMap → map` queryFn that emulates a live database query.
- One `setup()` helper per suite (component shape differs: plain component vs. hide/show host), plus a local `expectData` assertion helper.

**Why they are truly the same concept**

All 10 copies exercise the same fixture — "a live query backed by a db-readiness gate that re-emits a fresh array on every push" — against the same rendered output. They were copy-pasted, differing only in query key, initial items, and (in two tests) query options, which are now plain parameters. No behavior changes: query keys, options (including the two tests that intentionally omit `staleTime: Infinity`), emission sequences, timings, and assertions are byte-for-byte equivalent, and the two-observers test keeps its bespoke double-hook component.

**Gates** (same commands CI runs, all green before and after; 139/139 tests pass both times)

- `npm run check`
- `npm run build` (tsc + vite)
- `npm run test:ci`

**Other candidates surveyed and rejected**

- `useSwitchMutation$` / `useConcatMutation$`: shared adapters were already extracted (`mutationOptions.ts`); the remaining similarity is genuinely divergent cancellation semantics (abort vs. ready-gate).
- `createLocalStorageAdapter` / `createLocalforageAdapter`: superficially similar JSON (de)serialization but different backends with intentionally different `removeItem`/`clear` semantics.
- Remaining jscpd hits (`persistSignals.test.ts`, `useObserve.compare.test.tsx`, `useSwitchMutation$.test.tsx`) are small intra-file test-case variations; consolidating them would trade readability for little LOC — possible future runs if they grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zuCUHEHA1tWwYQ28x4rgB

---
_Generated by [Claude Code](https://claude.ai/code/session_015zuCUHEHA1tWwYQ28x4rgB)_