### PR TITLE
fix: restart the persistence process when usePersistSignals entries change

### DIFF
--- a/src/lib/state/react/usePersistSignals.test.tsx
+++ b/src/lib/state/react/usePersistSignals.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import type { Adapter } from "../persistence/adapters/Adapter"
+import { IDENTIFIER_PERSISTENCE_KEY } from "../persistence/constants"
+import type {
+  PersistenceEntry,
+  SignalPersistenceConfig,
+} from "../persistence/types"
+import { signal } from "../Signal"
+import { usePersistSignals } from "./usePersistSignals"
+
+const createMemoryAdapter = (
+  storage: Record<string, unknown> = {},
+): Adapter & { storage: Record<string, unknown> } => ({
+  storage,
+  getItem: async (key: string) => storage[key],
+  setItem: async (key: string, value: unknown) => {
+    storage[key] = value
+  },
+  removeItem: async (key: string) => {
+    delete storage[key]
+  },
+  clear: async () => {},
+})
+
+describe("Given an entry added after the initial hydration", () => {
+  it("should hydrate and persist the new entry", {
+    timeout: 3000,
+  }, async () => {
+    const signalA = signal({ default: 0, key: "a" })
+    const signalB = signal({ default: 0, key: "b" })
+
+    const adapter = createMemoryAdapter({
+      b: {
+        [IDENTIFIER_PERSISTENCE_KEY]: IDENTIFIER_PERSISTENCE_KEY,
+        value: 7,
+        migrationVersion: 0,
+      } satisfies PersistenceEntry,
+    })
+
+    // biome-ignore lint/suspicious/noExplicitAny: test
+    const initialEntries: Array<SignalPersistenceConfig<any>> = [
+      { signal: signalA, version: 0 },
+    ]
+    // biome-ignore lint/suspicious/noExplicitAny: test
+    const updatedEntries: Array<SignalPersistenceConfig<any>> = [
+      { signal: signalA, version: 0 },
+      { signal: signalB, version: 0 },
+    ]
+
+    const { result, rerender } = renderHook(
+      ({ entries }) => usePersistSignals({ entries, adapter }),
+      { initialProps: { entries: initialEntries } },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isHydrated).toBe(true)
+    })
+
+    expect(signalB.getValue()).toBe(0)
+
+    rerender({ entries: updatedEntries })
+
+    await waitFor(() => {
+      expect(signalB.getValue()).toBe(7)
+    })
+
+    signalB.update(9)
+
+    await waitFor(
+      () => {
+        expect((adapter.storage.b as PersistenceEntry | undefined)?.value).toBe(
+          9,
+        )
+      },
+      { timeout: 2000 },
+    )
+  })
+})

--- a/src/lib/state/react/usePersistSignals.tsx
+++ b/src/lib/state/react/usePersistSignals.tsx
@@ -1,4 +1,4 @@
-import { concatMap, merge, of, scan, switchMap } from "rxjs"
+import { merge, of, scan, switchMap } from "rxjs"
 import { useLiveBehaviorSubject } from "../../binding/useLiveBehaviorSubject"
 import { useObserve } from "../../binding/useObserve/useObserve"
 import { useLiveRef } from "../../utils/react/useLiveRef"
@@ -20,9 +20,8 @@ export function usePersistSignals({
   adapter,
 }: {
   /**
-   * Passing a new list of entries will start over the process
-   * once the current one is finished. Use a stable reference to avoid
-   * infinite loop.
+   * Passing a new list of entries will start over the process.
+   * Use a stable reference to avoid infinite loop.
    */
 
   // biome-ignore lint/suspicious/noExplicitAny: TODO
@@ -51,7 +50,13 @@ export function usePersistSignals({
           return merge(
             of({ type: "reset" }),
             entriesSubject.pipe(
-              concatMap((entries) =>
+              /**
+               * `persistSignals` never completes on its own (it keeps
+               * persisting signal updates), so a sequential operator would
+               * queue new entries forever. Restart the process instead
+               * whenever a new list is emitted.
+               */
+              switchMap((entries) =>
                 persistSignals({
                   adapter,
                   entries,


### PR DESCRIPTION
## The bug

`usePersistSignals` documents that "Passing a new list of entries will start over the process" — but entries passed after the initial hydration are silently ignored: they are never hydrated from storage and their updates are never persisted.

**How to observe:** render `usePersistSignals({ entries: [a], adapter })`, wait for `isHydrated`, then re-render with `entries: [a, b]` where storage already holds a value for `b`'s key. Signal `b` keeps its default value forever (stored value never hydrated), and updates to `b` are never written to the adapter. Only the original entry `a` keeps working.

## Root cause

In `usePersistSignals`, entries emissions are piped through `concatMap(persistSignals)`:

```ts
entriesSubject.pipe(
  concatMap((entries) => persistSignals({ adapter, entries, ... })),
)
```

`concatMap` only subscribes to the next inner observable once the previous one **completes** — but the observable returned by `persistSignals` never completes on its own: after hydrating, it keeps persisting signal updates indefinitely (`persisted$` is an infinite merge of the signals' streams). So every new entries list is queued behind an inner observable that never finishes, and is starved forever.

## The fix

Use `switchMap` instead, mirroring the adapter-change path a few lines above (which already uses `switchMap`): a new entries list tears down the previous hydrate-and-persist process and starts a fresh one, as documented. The stale "once the current one is finished" phrasing in the `entries` doc comment is updated to match.

## Verification

New regression test `src/lib/state/react/usePersistSignals.test.tsx`:
1. hydrates with `[a]`, waits for `isHydrated`,
2. re-renders with `[a, b]` where storage holds `7` for `b` → asserts `b` hydrates to `7`,
3. updates `b` to `9` → asserts the adapter receives the write.

The test times out on `main` (step 2 never happens) and passes with the fix. Full gates run locally: `npm run check`, `npm run build`, and `npm run test:ci` (25 files / 140 tests) all pass. (`useQuery$.test.tsx > should return consecutive results` timed out once on a clean `main` baseline under parallel load but passes in isolation and in the post-fix full run — pre-existing flake, unrelated.)

## Other findings (not addressed in this PR)

- None confirmed. Notable candidates investigated and discarded: `queryClient.clear()` while a live-stream `useQuery$` is mounted looked like it would leave a stale bridge cache entry, but TanStack's `cache.remove()` calls `query.destroy()`, which aborts the fetch signal and the bridge's `takeUntil(fromEvent(signal, "abort"))` tears the entry down correctly (verified empirically against a promise-based baseline).


---
_Generated by [Claude Code](https://claude.ai/code/session_0152ZzwVACMdMfk6jt7Ezzkn)_